### PR TITLE
Add offline demo data

### DIFF
--- a/app/src/components/ClientList.jsx
+++ b/app/src/components/ClientList.jsx
@@ -2,18 +2,40 @@ import { useEffect, useState } from 'react';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../firebase';
 
+const fallbackClients = [
+  {
+    id: 'demo1',
+    companyId: 'A100',
+    nombre: 'Cliente Demo 1',
+    proyecto: 'Proyecto Demo 1',
+    email: 'demo1@example.com',
+  },
+  {
+    id: 'demo2',
+    companyId: 'A101',
+    nombre: 'Cliente Demo 2',
+    proyecto: 'Proyecto Demo 2',
+    email: 'demo2@example.com',
+  },
+];
+
 export default function ClientList({ onSelect }) {
   const [clients, setClients] = useState([]);
   const [filters, setFilters] = useState({ companyId: '', nombre: '', proyecto: '', email: '' });
 
   useEffect(() => {
     const fetchClients = async () => {
-      const querySnapshot = await getDocs(collection(db, 'clientes'));
-      const data = [];
-      querySnapshot.forEach((doc) => {
-        data.push({ id: doc.id, ...doc.data() });
-      });
-      setClients(data);
+      try {
+        const querySnapshot = await getDocs(collection(db, 'clientes'));
+        const data = [];
+        querySnapshot.forEach((doc) => {
+          data.push({ id: doc.id, ...doc.data() });
+        });
+        setClients(data);
+      } catch (err) {
+        console.error(err);
+        setClients(fallbackClients);
+      }
     };
 
     fetchClients();

--- a/app/src/components/Payments.jsx
+++ b/app/src/components/Payments.jsx
@@ -2,6 +2,27 @@ import { useEffect, useState } from 'react';
 import { collection, addDoc, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../firebase';
 
+const fallbackPayments = {
+  A100: [
+    {
+      id: 'fp1',
+      monto: 32000,
+      fecha: '2025-07-05',
+      proximo: '2025-08-05',
+      meses: 1,
+    },
+  ],
+  A101: [
+    {
+      id: 'fp2',
+      monto: 90000,
+      fecha: '2025-04-05',
+      proximo: '2025-07-05',
+      meses: 3,
+    },
+  ],
+};
+
 export default function Payments({ client }) {
   const [payments, setPayments] = useState([]);
   const [form, setForm] = useState({ monto: '', fecha: '', proximo: '', meses: '' });
@@ -9,11 +30,16 @@ export default function Payments({ client }) {
   useEffect(() => {
     const fetchPayments = async () => {
       if (!client) return;
-      const q = query(collection(db, 'pagos'), where('companyId', '==', client.companyId));
-      const querySnapshot = await getDocs(q);
-      const data = [];
-      querySnapshot.forEach((doc) => data.push({ id: doc.id, ...doc.data() }));
-      setPayments(data);
+      try {
+        const q = query(collection(db, 'pagos'), where('companyId', '==', client.companyId));
+        const querySnapshot = await getDocs(q);
+        const data = [];
+        querySnapshot.forEach((doc) => data.push({ id: doc.id, ...doc.data() }));
+        setPayments(data);
+      } catch (err) {
+        console.error(err);
+        setPayments(fallbackPayments[client.companyId] || []);
+      }
     };
     fetchPayments();
   }, [client]);
@@ -21,19 +47,26 @@ export default function Payments({ client }) {
   const addPayment = async (e) => {
     e.preventDefault();
     if (!client) return;
-    await addDoc(collection(db, 'pagos'), {
+    const newPayment = {
       companyId: client.companyId,
       monto: Number(form.monto),
       fecha: form.fecha,
       proximo: form.proximo,
       meses: Number(form.meses),
-    });
-    setForm({ monto: '', fecha: '', proximo: '', meses: '' });
-    const q = query(collection(db, 'pagos'), where('companyId', '==', client.companyId));
-    const querySnapshot = await getDocs(q);
-    const data = [];
-    querySnapshot.forEach((doc) => data.push({ id: doc.id, ...doc.data() }));
-    setPayments(data);
+    };
+    try {
+      await addDoc(collection(db, 'pagos'), newPayment);
+      setForm({ monto: '', fecha: '', proximo: '', meses: '' });
+      const q = query(collection(db, 'pagos'), where('companyId', '==', client.companyId));
+      const querySnapshot = await getDocs(q);
+      const data = [];
+      querySnapshot.forEach((doc) => data.push({ id: doc.id, ...doc.data() }));
+      setPayments(data);
+    } catch (err) {
+      console.error(err);
+      setPayments(p => [...p, { id: Date.now().toString(), ...newPayment }]);
+      setForm({ monto: '', fecha: '', proximo: '', meses: '' });
+    }
   };
 
   if (!client) return null;


### PR DESCRIPTION
## Summary
- provide fallback clients when Firestore cannot be reached
- provide fallback payments and handle offline add

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875c2962b18832785eddfa58fdbdb72